### PR TITLE
Use unix EOL before transforming. Handle multi-dash horizontal lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ J2M.prototype.jira_to_html = function(str) {
 
 J2M.prototype.to_markdown = function(str) {
     return str
+        // convert to unix eol
+        .replace(/\r\n/g, '\n')
         // Ordered Lists
         .replace(/^[ \t]*(\*+)\s+/gm, function(match, stars) {
             return Array(stars.length).join(" ") + '* ';
@@ -42,6 +44,8 @@ J2M.prototype.to_markdown = function(str) {
         .replace(/\^([^^]*)\^/g, '<sup>$1</sup>')
         // Subscript
         .replace(/~([^~]*)~/g, '<sub>$1</sub>')
+        // horizontal line: reduce to 3 dashes to avoid hitting strikethrough rule
+        .replace(/^\-{3,}$/gm, '---')
         // Strikethrough
         .replace(/-(\S+.*?\S)-/g, '~~$1~~')
         // Code Block

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -107,4 +107,12 @@ describe('to_markdown', function() {
         var markdown = j2m.to_markdown("A text with{color:blue} blue \n lines {color} is not necessary.");
         markdown.should.eql("A text with blue \n lines  is not necessary.");
     });
+    it('should handle DOS eol', function() {
+        var markdown = j2m.to_markdown("{panel:title=A title}\r\nPanel text\r\n{panel}\r\n");
+        markdown.should.eql("\n| A title |\n| --- |\n| Panel text |\n");
+    });
+    it('should handle multi-dash horizontal lines', function() {
+        var markdown = j2m.to_markdown("-----\n");
+        markdown.should.eql("---\n");
+    });
 });


### PR DESCRIPTION
@kylefarris Realized that the regex I added in the previous PR were breaking with `\r\n` eol (which the Jira API uses). I took the approach of converting the str before applying transforming. To be completely correct, one would have to convert back to `os.EOL` at the end, but I'm not sure it's worth it. Let me know if you prefer me to do that.

I also hit the case where a horizontal line in Jira was written as more than three dashes. This got interpreted as a strikethrough.

I added two test cases testing the changes.