### PR TITLE
Added support for tables in markdown files with CRLF line endings

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ J2M.prototype.to_jira = function(str) {
         // Single Paragraph Blockquote
         .replace(/^>/gm, 'bq.')
         // tables
-        .replace(/^\n((?:\|.*?)+\|)[ \t]*\n((?:\|\s*?\-{3,}\s*?)+\|)[ \t]*\n((?:(?:\|.*?)+\|[ \t]*\n)*)$/gm,
+        .replace(/^\r?\n((?:\|.*?)+\|)[ \t]*\r?\n((?:\|\s*?\-{3,}\s*?)+\|)[ \t]*\r?\n((?:(?:\|.*?)+\|[ \t]*\r?\n)*)$/gm,
                  function (match, headerLine, separatorLine, rowstr) {
                      var headers = headerLine.match(/[^|]+(?=\|)/g);
                      var separators = separatorLine.match(/[^|]+(?=\|)/g);


### PR DESCRIPTION
I was just wondering why my tables were not converted. Found that the regex used or md-table detection does not care about possible CR characters (```\r```) in front of a line break.

### Another issue

A follow-up issue can be the missing support of tables without bounding pipe characters (```|```):

    A | B
    --|--
    1 | 2