### PR TITLE
jira to md: code blocks with title were not converting

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ J2M.prototype.to_markdown = function(str) {
     return str
         // Ordered Lists
         .replace(/^[ \t]*(\*+)\s+/gm, function(match, stars) {
-            return Array(stars.length).join(" ") + '* ';
+            return Array(stars.length).join("  ") + '* ';
         })
         // Un-ordered lists
         .replace(/^[ \t]*(#+)\s+/gm, function(match, nums) {
-            return Array(nums.length).join(" ") + '1. ';
+            return Array(nums.length).join("  ") + '1. ';
         })
         // Headers 1-6
         .replace(/^h([0-6])\.(.*)$/gm, function (match, level, content) {
@@ -45,7 +45,7 @@ J2M.prototype.to_markdown = function(str) {
         // Strikethrough
         .replace(/-(\S+.*?\S)-/g, '~~$1~~')
         // Code Block
-        .replace(/\{code(:([a-z]+))?\}([^]*)\{code\}/gm, '```$2$3```')
+        .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*)\{code\}/gm, '```$2$5```')
         // Pre-formatted text
         .replace(/{noformat}/g, '```')
         // Un-named Links
@@ -97,11 +97,11 @@ J2M.prototype.to_jira = function(str) {
          })
         // Ordered lists
         .replace(/^([ \t]*)\d+\.\s+/gm, function(match, spaces) {
-            return Array(spaces.length + 1).join("#") + '# ';
+            return Array(Math.floor(spaces.length/2 + 1)).join("#") + '# ';
         })
         // Un-Ordered Lists
         .replace(/^([ \t]*)\*\s+/gm, function(match, spaces) {
-            return Array(spaces.length + 1).join("*") + '* ';
+            return Array(Math.floor(spaces.length/2 + 1)).join("*") + '* ';
         })
         // Headers (h1 or h2) (lines "underlined" by ---- or =====)
         // Citations, Inserts, Subscripts, Superscripts, and Strikethroughs

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ J2M.prototype.to_markdown = function(str) {
         // Monospaced text
         .replace(/\{\{([^}]+)\}\}/g, '`$1`')
         // Citations
-        //.replace(/\?\?((?:.[^?]|[^?].)+)\?\?/g, '<cite>$1</cite>')
+        .replace(/\?\?((?:.[^?]|[^?].)+)\?\?/g, '<cite>$1</cite>')
         // Inserts
         .replace(/\+([^+]*)\+/g, '<ins>$1</ins>')
         // Superscript

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -23,10 +23,10 @@ describe('to_markdown', function() {
         var markdown = j2m.to_markdown('{{monospaced}}');
         markdown.should.eql('`monospaced`');
     });
-    //it('should convert citations properly', function() {
-    //    var markdown = j2m.to_markdown('??citation??');
-    //    markdown.should.eql('<cite>citation</cite>');
-    //});
+    it('should convert citations properly', function() {
+        var markdown = j2m.to_markdown('??citation??');
+        markdown.should.eql('<cite>citation</cite>');
+    });
     it('should convert strikethroughs properly', function() {
         var markdown = j2m.to_markdown('-deleted-');
         markdown.should.eql('~~deleted~~');

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -23,10 +23,10 @@ describe('to_markdown', function() {
         var markdown = j2m.to_markdown('{{monospaced}}');
         markdown.should.eql('`monospaced`');
     });
-    it('should convert citations properly', function() {
-        var markdown = j2m.to_markdown('??citation??');
-        markdown.should.eql('<cite>citation</cite>');
-    });
+    //it('should convert citations properly', function() {
+    //    var markdown = j2m.to_markdown('??citation??');
+    //    markdown.should.eql('<cite>citation</cite>');
+    //});
     it('should convert strikethroughs properly', function() {
         var markdown = j2m.to_markdown('-deleted-');
         markdown.should.eql('~~deleted~~');
@@ -50,6 +50,24 @@ describe('to_markdown', function() {
     it('should convert language-specific code blocks properly', function() {
         var markdown = j2m.to_markdown("{code:javascript}\nvar hello = 'world';\n{code}");
         markdown.should.eql("```javascript\nvar hello = 'world';\n```");
+    });
+    it('should convert code without language-specific and with title into code block', function() {
+        var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
+        markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```")
+    });
+    it('should convert fully configured code block', function() {
+        var markdown = j2m.to_markdown(
+            "{code:xml|title=My Title|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}"
+            + "\n    <test>"
+            + "\n        <another tag=\"attribute\"/>"
+            + "\n    </test>"
+            + "\n{code}");
+        markdown.should.eql(
+            "```xml"
+            + "\n    <test>"
+            + "\n        <another tag=\"attribute\"/>"
+            + "\n    </test>"
+            + "\n```");
     });
     it('should convert unnamed links properly', function() {
         var markdown = j2m.to_markdown("[http://google.com]");
@@ -79,11 +97,11 @@ describe('to_markdown', function() {
     });
     it('should convert un-ordered lists properly', function() {
         var markdown = j2m.to_markdown("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
-        markdown.should.eql("* Foo\n* Bar\n* Baz\n * FooBar\n * BarBaz\n  * FooBarBaz\n* Starting Over");
+        markdown.should.eql("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
     });
     it('should convert ordered lists properly', function() {
         var markdown = j2m.to_markdown("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
-        markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n 1. FooBar\n 1. BarBaz\n  1. FooBarBaz\n1. Starting Over");
+        markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
     });
     it('should handle bold AND italic (combined) correctly', function() {
         var markdown = j2m.to_markdown("This is _*emphatically bold*_!");
@@ -91,7 +109,7 @@ describe('to_markdown', function() {
     });
     it('should handle bold within a un-ordered list item', function() {
         var markdown = j2m.to_markdown("* This is not bold!\n** This is *bold*.");
-        markdown.should.eql("* This is not bold!\n * This is **bold**.");
+        markdown.should.eql("* This is not bold!\n  * This is **bold**.");
     });
     it('should be able to handle a complicated multi-line jira-wiki string and convert it to markdown', function() {
         var jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'),"utf8");

--- a/test/md2jira.js
+++ b/test/md2jira.js
@@ -84,11 +84,11 @@ describe('to_jira', function() {
         jira.should.eql("bq. This is a long blockquote type thingy that needs to be converted.");
     });
     it('should convert un-ordered lists properly', function() {
-        var jira = j2m.to_jira("* Foo\n* Bar\n* Baz\n * FooBar\n * BarBaz\n  * FooBarBaz\n* Starting Over");
+        var jira = j2m.to_jira("* Foo\n* Bar\n* Baz\n  * FooBar\n  * BarBaz\n    * FooBarBaz\n* Starting Over");
         jira.should.eql("* Foo\n* Bar\n* Baz\n** FooBar\n** BarBaz\n*** FooBarBaz\n* Starting Over");
     });
     it('should convert ordered lists properly', function() {
-        var jira = j2m.to_jira("1. Foo\n1. Bar\n1. Baz\n 1. FooBar\n 1. BarBaz\n  1. FooBarBaz\n1. Starting Over");
+        var jira = j2m.to_jira("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
         jira.should.eql("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
     });
     it('should handle bold AND italic (combined) correctly', function() {
@@ -96,7 +96,7 @@ describe('to_jira', function() {
         jira.should.eql("This is _*emphatically bold*_!");
     });
     it('should handle bold within a un-ordered list item', function() {
-        var jira = j2m.to_jira("* This is not bold!\n * This is **bold**.");
+        var jira = j2m.to_jira("* This is not bold!\n  * This is **bold**.");
         jira.should.eql("* This is not bold!\n** This is *bold*.");
     });
     it('should be able to handle a complicated multi-line markdown string and convert it to markdown', function() {

--- a/test/test.jira
+++ b/test/test.jira
@@ -12,7 +12,6 @@ h6. Smallest heading
 *strong*
 _emphasis_
 {{monospaced}}
-??citation??
 -deleted-
 +inserted+
 ^superscript^

--- a/test/test.jira
+++ b/test/test.jira
@@ -12,6 +12,7 @@ h6. Smallest heading
 *strong*
 _emphasis_
 {{monospaced}}
+??citation??
 -deleted-
 +inserted+
 ^superscript^

--- a/test/test.md
+++ b/test/test.md
@@ -12,7 +12,6 @@
 **strong**
 *emphasis*
 `monospaced`
-<cite>citation</cite>
 ~~deleted~~
 <ins>inserted</ins>
 <sup>superscript</sup>
@@ -37,20 +36,20 @@ GitHub Flavor
 
 * First li
 * Second li
- * Indented li
-  * Three columns in li
+  * Indented li
+    * Three columns in li
 * Back to first level li
 
 1. First li
 1. Second li
- 1. Indented li
-  1. Three columns in li
+  1. Indented li
+    1. Three columns in li
 1. Back to first level li
 
 * Here's *italic* inside li
 * here's **bold** inside li
 * Here's ***bold + italic*** inside li
- * Here they are in one line indented: *italic* **bold**
+  * Here they are in one line indented: *italic* **bold**
 
 > Here's a long single-paragraph block quote. It should look pretty and stuff.
 

--- a/test/test.md
+++ b/test/test.md
@@ -12,6 +12,7 @@
 **strong**
 *emphasis*
 `monospaced`
+<cite>citation</cite>
 ~~deleted~~
 <ins>inserted</ins>
 <sup>superscript</sup>


### PR DESCRIPTION
md: generated and converted (un)ordered lists should double leading spaces