### PR TITLE
fixes markdown conversion when there is no \n before the ending {code} marker

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ J2M.prototype.to_markdown = function(str) {
         // Strikethrough
         .replace(/(\s+)-(\S+.*?\S)-(\s+)/g, '$1~~$2~~$3')
         // Code Block
-        .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*)\{code\}/gm, '```$2$5```')
+        .replace(/\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*?)\n?\{code\}/gm, '```$2$5\n```')
         // Pre-formatted text
         .replace(/{noformat}/g, '```')
         // Un-named Links

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -55,6 +55,10 @@ describe('to_markdown', function() {
         var markdown = j2m.to_markdown("{code:title=Foo.java}\nclass Foo {\n  public static void main() {\n  }\n}\n{code}");
         markdown.should.eql("```\nclass Foo {\n  public static void main() {\n  }\n}\n```")
     });
+    it('should convert code without line feed before the end code block', function() {
+        var markdown = j2m.to_markdown("{code:java}\njava code{code}");
+        markdown.should.eql("```java\njava code\n```")
+    });
     it('should convert fully configured code block', function() {
         var markdown = j2m.to_markdown(
             "{code:xml|title=My Title|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}"

--- a/test/test.md
+++ b/test/test.md
@@ -19,7 +19,7 @@
 
 ```javascript
 var hello = 'world';
-{code}
+```
 
 ![](http://google.com/image)
 [![](http://google.com/image)](http://google.com/link)
@@ -30,7 +30,7 @@ var hello = 'world';
 GitHub Flavor
 ~~deleted~~
 
-{code}
+```
   preformatted piece of text
   so *no_ further _formatting* is done here
 ```


### PR DESCRIPTION
I encountered an issue when parsing a JIRA text where there was no end line before the ending {code} marker.
This is my attempt to fix it.

Fixing this fixed another pre-existing issue shown by the  `should be able to handle a complicated multi-line jira-wiki string and convert it to markdown` test where the code blocs where not escaped properly. (1 single code bloc instead of 2)
