### PR TITLE
Fix insertions being converted across table cells

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,3 +22,7 @@ This file is a manually maintained list of changes for each release. Feel free t
 ## 2.0.3 (2017-09-15)
 
 * Fixed a bug where dashes were being converted to strike throughs in situations they shouldn't have been. Before the fix, the string "ABC-1234 and DEF-5678" would have been converted to (HTML): "ABC<del>1234 and DEV</del>5678" or (Markdown): "ABC~~1234 and DEV~~5678" which is invalid. After the fix, no strikethroughs will be added to the converted output unless there is at least 1 space before the first dash (or double tilde) and after the last dash (or double tilde).
+
+## 2.1.1 (2020-04-08)
+
+* Fixed insertions (+) being converted to tags across table cells. Before the fix, table rows such as "|some+string|something+else|" would have been converted to "|some<ins>string|something</ins>else|". After the fix, insertions are not converted if they are both inside a different table cell (both + characters are delimited by pipe characters). 

--- a/index.js
+++ b/index.js
@@ -66,8 +66,15 @@ J2M.prototype.to_markdown = function(str) {
             return '\n' + singleBarred + '\n' + singleBarred.replace(/\|[^|]+/g, '| --- ');
         })
         // remove leading-space of table headers and rows
-        .replace(/^[ \t]*\|/gm, '|');
-
+        .replace(/^[ \t]*\|/gm, '|')
+        // remove unterminated inserts across table cells
+        .replace(/\|([^<]*)<ins>(?![^|]*<\/ins>)([^|]*)\|/g, function (_, preceding, following) {
+            return '|' + preceding + '+' + following + '|'
+        })
+        // remove unopened inserts across table cells
+        .replace(/\|(?<![^|]*<ins>)([^<]*)<\/ins>([^|]*)\|/g, function (_, preceding, following) {
+            return '|' + preceding + '+' + following + '|'
+        });
 };
 
 J2M.prototype.to_jira = function(str) {

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -137,4 +137,8 @@ describe('to_markdown', function() {
         var markdown = j2m.to_markdown("A text with{color:blue} blue \n lines {color} is not necessary.");
         markdown.should.eql("A text with blue \n lines  is not necessary.");
     });
+    it('should not recognize inserts across multiple table cells', function() {
+        var markdown = j2m.to_markdown('||Heading 1||Heading 2||\n|Col+A1|Col+A2|');
+        markdown.should.eql('\n|Heading 1|Heading 2|\n| --- | --- |\n|Col+A1|Col+A2|');
+    });
 });


### PR DESCRIPTION
Fixed insertions (+) being converted to tags across table cells.
Before the fix, table rows such as "|some+string|something+else|"
would have been converted to "|somestring|somethingelse|". After
the fix, insertions are not converted if they are both inside
a different table cell (both + characters are delimited by
pipe characters).

This broke e.g. table cells e-mails containing plus signs; the e-mail link href would only contain the part after the plus sign.