### PR TITLE
Fixing marked to html methods; Ordered and un-ordered list should have 3 spaces instead of 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ J2M.prototype.to_markdown = function(str) {
     return str
         // Ordered Lists
         .replace(/^[ \t]*(\*+)\s+/gm, function(match, stars) {
-            return Array(stars.length).join("  ") + '* ';
+            return Array(stars.length).join("   ") + '* ';
         })
         // Un-ordered lists
         .replace(/^[ \t]*(#+)\s+/gm, function(match, nums) {
-            return Array(nums.length).join("    ") + '1. ';
+            return Array(nums.length).join("   ") + '1. ';
         })
         // Headers 1-6
         .replace(/^h([0-6])\.(.*)$/gm, function (match, level, content) {

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
-var marked = require('marked');
+const marked = require('marked');
 marked.setOptions({
 	breaks: true,
 	smartyPants: true
 });
 
-var J2M = function() {};
+const J2M = function() {};
 
 J2M.prototype.md_to_html = function(str) {
-	return marked(str);
+	return marked.parse(str);
 };
 
 J2M.prototype.jira_to_html = function(str) {
-	return marked(this.to_markdown(str));
+	return marked.parse(this.to_markdown(str));
 };
 
 J2M.prototype.to_markdown = function(str) {
@@ -22,7 +22,7 @@ J2M.prototype.to_markdown = function(str) {
         })
         // Un-ordered lists
         .replace(/^[ \t]*(#+)\s+/gm, function(match, nums) {
-            return Array(nums.length).join("  ") + '1. ';
+            return Array(nums.length).join("    ") + '1. ';
         })
         // Headers 1-6
         .replace(/^h([0-6])\.(.*)$/gm, function (match, level, content) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira2md",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jira2md",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "marked": "^4.0.12"

--- a/test/jira2md.js
+++ b/test/jira2md.js
@@ -113,7 +113,7 @@ describe('to_markdown', function() {
     });
     it('should convert ordered lists properly', function() {
         var markdown = j2m.to_markdown("# Foo\n# Bar\n# Baz\n## FooBar\n## BarBaz\n### FooBarBaz\n# Starting Over");
-        markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n  1. FooBar\n  1. BarBaz\n    1. FooBarBaz\n1. Starting Over");
+        markdown.should.eql("1. Foo\n1. Bar\n1. Baz\n    1. FooBar\n    1. BarBaz\n        1. FooBarBaz\n1. Starting Over");
     });
     it('should handle bold AND italic (combined) correctly', function() {
         var markdown = j2m.to_markdown("This is _*emphatically bold*_!");

--- a/test/test.md
+++ b/test/test.md
@@ -45,8 +45,8 @@ GitHub Flavor
 
 1. First li
 1. Second li
-  1. Indented li
-    1. Three columns in li
+    1. Indented li
+        1. Three columns in li
 1. Back to first level li
 
 * Here's *italic* inside li

--- a/test/test_file.html
+++ b/test/test_file.html
@@ -1,0 +1,77 @@
+<h1 id="biggest-heading">Biggest heading</h1>
+<h2 id="bigger-heading">Bigger heading</h2>
+<h1 id="biggest-heading-1">Biggest heading</h1>
+<h2 id="bigger-heading-1">Bigger heading</h2>
+<h3 id="big-heading">Big heading</h3>
+<h4 id="normal-heading">Normal heading</h4>
+<h5 id="small-heading">Small heading</h5>
+<h6 id="smallest-heading">Smallest heading</h6>
+<p><strong>strong</strong><br><em>emphasis</em><br><code>monospaced</code><br><del>deleted</del><br><ins>inserted</ins><br><sup>superscript</sup><br><sub>subscript</sub></p>
+<pre><code class="language-javascript">var hello = &#39;world&#39;;
+</code></pre>
+<p><img src="http://google.com/image" alt=""><br><a href="http://google.com/link"><img src="http://google.com/image" alt=""></a></p>
+<p><a href="http://google.com">http://google.com</a><br><a href="http://google.com">Google</a></p>
+<p>GitHub Flavor<br><del>deleted</del></p>
+<pre><code>  preformatted piece of text
+  so *no_ further _formatting* is done here
+</code></pre>
+<p><em><strong>Should be bold AND italic</strong></em></p>
+<ul>
+<li>First li</li>
+<li>Second li<ul>
+<li>Indented li<ul>
+<li>Three columns in li</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Back to first level li</li>
+</ul>
+<ol>
+<li>First li</li>
+<li>Second li<ol>
+<li>Indented li<ol>
+<li>Three columns in li</li>
+</ol>
+</li>
+</ol>
+</li>
+<li>Back to first level li</li>
+</ol>
+<ul>
+<li>Here&#39;s <em>italic</em> inside li</li>
+<li>here&#39;s <strong>bold</strong> inside li</li>
+<li>Here&#39;s <em><strong>bold + italic</strong></em> inside li<ul>
+<li>Here they are in one line indented: <em>italic</em> <strong>bold</strong></li>
+</ul>
+</li>
+</ul>
+<blockquote>
+<p>Here&#39;s a long single-paragraph block quote. It should look pretty and stuff.</p>
+</blockquote>
+<table>
+<thead>
+<tr>
+<th>A title</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Panel text</td>
+</tr>
+</tbody></table>
+<table>
+<thead>
+<tr>
+<th>Heading 1</th>
+<th>Heading 2</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Col A1</td>
+<td>Col A2</td>
+</tr>
+<tr>
+<td>Col B1</td>
+<td>Col B2</td>
+</tr>
+</tbody></table>

--- a/test/to_html.js
+++ b/test/to_html.js
@@ -1,0 +1,42 @@
+const j2m = require("../index");
+const should = require('chai').should();
+const fs = require('fs');
+const path = require('path');
+
+describe("md_to_html", () => {
+
+    it('should exist', function() {
+        should.exist(j2m.md_to_html(""));
+    });
+
+    it('should be a function', function() {
+        j2m.md_to_html.should.be.a('function');
+    });
+
+    it('should provide html from md', function () {
+        const md_str = fs.readFileSync(path.resolve(__dirname, 'test.md'),"utf8");
+        const html_str = fs.readFileSync(path.resolve(__dirname, 'test_file.html'),"utf8");
+
+        const html = j2m.md_to_html(md_str);
+        html.should.eql(html_str);
+    });
+});
+
+describe("jira_to_html", () => {
+
+    it('should exist', function() {
+        should.exist(j2m.jira_to_html(""));
+    });
+
+    it('should be a function', function() {
+        j2m.jira_to_html.should.be.a('function');
+    });
+
+    it('should provide html from md', function () {
+        const jira_str = fs.readFileSync(path.resolve(__dirname, 'test.jira'),"utf8");
+        const html_str = fs.readFileSync(path.resolve(__dirname, 'test_file.html'),"utf8");
+
+        const html = j2m.jira_to_html(jira_str);
+        html.should.eql(html_str);
+    });
+});


### PR DESCRIPTION
Marked version ^4 has different usage. From now marked is an _object_ which has _parse_() method and it should be called. 
After a lot of testing I figured out that marked needs 3 spaces of indents for ordered lists instead of 2 spaces and it is in default MD documentation.