### PR TITLE
Parsing for emoticons, offered in Jira tickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build/Release
 node_modules
 
 .DS_Store
+.vscode/settings.json

--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ class J2M {
                 .replace(/\(\?\)/g, '❓')
                 .replace(/<3/g, '❤️')
                 .replace(/<\/3/g, '💔')
+
+                .replace(/\(flag\)/g, '🚩')
+                .replace(/\(flagoff\)/g, '🏳️')
                 // Un-Ordered Lists
                 .replace(/^[ \t]*(\*+)\s+/gm, (match, stars) => {
                     return `${Array(stars.length).join('  ')}* `;
@@ -224,36 +227,38 @@ class J2M {
                 .replace(/<([^>]+)>/g, '[$1]')
                 // Single Paragraph Blockquote
                 .replace(/^>/gm, 'bq.')
-            // Jira emoticons https://confluence.atlassian.com/doc/files/136870/947169184/1/1521512577368/Emoticons.png
-            // TODO:
-            // .replace(/:\)/g, '😊')
-            // .replace(/:\(/g, '☹️')
-            // .replace(/:p/g, '😛')
-            // .replace(/:P/g, '😛')
-            // .replace(/:D/g, '😀')
-            // .replace(/;\)/g, '😉')
+                // Jira emoticons https://confluence.atlassian.com/doc/files/136870/947169184/1/1521512577368/Emoticons.png
+                //   TODO: test the following
+                .replace('😊', ':')
+                .replace('☹️', ':')
+                .replace('😛', ':p')
+                .replace('😀', ':D')
+                .replace('😉', ';)')
 
-            // .replace(/\(y\)/g, '👍')
-            // .replace(/\(n\)/g, '👎')
-            // .replace(/\(on\)/g, '(ON)')
-            // .replace(/\(off\)/g, '(OFF)')
-            // .replace(/\(!\)/g, '⚠️')
+                .replace('👍', '(y)')
+                .replace('👎', '(n)')
+                .replace('(ON)', '(on)')
+                .replace('(OFF)', '(off)')
+                .replace('⚠️', '(!)')
 
-            // .replace(/\(\*\)/g, '⭐')
-            // .replace(/\(\*r\)/g, '⭐(red)')
-            // .replace(/\(\*g\)/g, '⭐(green)')
-            // .replace(/\(\*b\)/g, '⭐(blue)')
-            // .replace(/\(\*y\)/g, '⭐(yellow)')
+                .replace('⭐', '(*)')
+                .replace('⭐(red)', '(*r)')
+                .replace('⭐(green)', '(*)')
+                .replace('⭐(blue)', '(*b)')
+                .replace('⭐(yellow)', '(*y)')
 
-            // .replace(/\(\/\)/g, '✅')
-            // .replace(/\(x\)/g, '❌')
-            // .replace(/\(i\)/g, 'ℹ️')
-            // .replace(/\(\+\)/g, '➕')
-            // .replace(/\(-\)/g, '➖')
+                .replace('✅', '(/)')
+                .replace('❌', '(x)')
+                .replace('ℹ️', '(i)')
+                .replace('➕', '(+)')
+                .replace('➖', '(-)')
 
-            // .replace(/\(\?\)/g, '❓')
-            // .replace(/<3/g, '❤️')
-            // .replace(/<\/3/g, '💔')
+                .replace('❓', '(?)')
+                .replace('❤️', '<3')
+                .replace('💔', '<3')
+
+                .replace('🚩', '(flag)')
+                .replace('🏳️', '(flagoff)')
         );
     }
 }

--- a/index.js
+++ b/index.js
@@ -105,7 +105,16 @@ class J2M {
                 // Un-named Links
                 .replace(/\[([^|]+?)\]/g, '<$1>')
                 // Images
-                .replace(/!(.+)!/g, '![]($1)')
+                // .replace(/!(.+)!/g, '![]($1)')
+                .replace(/!([^|!]+)\|?(.*)!/g, ($1, $2, $3) => {
+                    let size = '';
+                    if ($3 === 'thumbnail') {
+                        size = '|200';
+                    } else if ($3.includes('width=') && $3.includes('height=')) {
+                        size = $3.replace(/width=(\d+),height=(\d+)/g, '|$1x$2');
+                    }
+                    return `![${size}](${$2})`;
+                })
                 // Named Links
                 .replace(/\[(.+?)\|(.+?)\]/g, '[$1]($2)')
                 // Single Paragraph Blockquote
@@ -221,6 +230,16 @@ class J2M {
                 .replace(/`([^`]+)`/g, '{{$1}}')
                 // Images
                 .replace(/!\[[^\]]*\]\(([^)]+)\)/g, '!$1!')
+                // TODO: enable transformation of size-information
+                // .replace(/!([^|!]+)\|?(.*)!/g, ($1, $2, $3) => {
+                //     let size = '';
+                //     if ($3 === 'thumbnail') {
+                //         size = '|200';
+                //     } else if ($3.includes('width=') && $3.includes('height=')) {
+                //         size = $3.replace(/width=(\d+),height=(\d+)/g, '|$1x$2');
+                //     }
+                //     return `![${size}](${$2})`;
+                // })
                 // Named Link
                 .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1|$2]')
                 // Un-Named Link

--- a/index.js
+++ b/index.js
@@ -35,6 +35,35 @@ class J2M {
     static to_markdown(str) {
         return (
             str
+                // jira emoticons https://confluence.atlassian.com/doc/files/136870/947169184/1/1521512577368/Emoticons.png
+                .replace(/:\)/g, '😊')
+                .replace(/:\(/g, '☹️')
+                .replace(/:p/g, '😛')
+                .replace(/:P/g, '😛')
+                .replace(/:D/g, '😀')
+                .replace(/;\)/g, '😉')
+
+                .replace(/\(y\)/g, '👍')
+                .replace(/\(n\)/g, '👎')
+                .replace(/\(on\)/g, '(ON)')
+                .replace(/\(off\)/g, '(OFF)')
+                .replace(/\(!\)/g, '⚠️')
+
+                .replace(/\(\*\)/g, '⭐')
+                .replace(/\(\*r\)/g, '⭐(red)')
+                .replace(/\(\*g\)/g, '⭐(green)')
+                .replace(/\(\*b\)/g, '⭐(blue)')
+                .replace(/\(\*y\)/g, '⭐(yellow)')
+
+                .replace(/\(\/\)/g, '✅')
+                .replace(/\(x\)/g, '❌')
+                .replace(/\(i\)/g, 'ℹ️')
+                .replace(/\(\+\)/g, '➕')
+                .replace(/\(-\)/g, '➖')
+
+                .replace(/\(\?\)/g, '❓')
+                .replace(/<3/g, '❤️')
+                .replace(/<\/3/g, '💔')
                 // Un-Ordered Lists
                 .replace(/^[ \t]*(\*+)\s+/gm, (match, stars) => {
                     return `${Array(stars.length).join('  ')}* `;
@@ -195,6 +224,36 @@ class J2M {
                 .replace(/<([^>]+)>/g, '[$1]')
                 // Single Paragraph Blockquote
                 .replace(/^>/gm, 'bq.')
+            // Jira emoticons https://confluence.atlassian.com/doc/files/136870/947169184/1/1521512577368/Emoticons.png
+            // TODO:
+            // .replace(/:\)/g, '😊')
+            // .replace(/:\(/g, '☹️')
+            // .replace(/:p/g, '😛')
+            // .replace(/:P/g, '😛')
+            // .replace(/:D/g, '😀')
+            // .replace(/;\)/g, '😉')
+
+            // .replace(/\(y\)/g, '👍')
+            // .replace(/\(n\)/g, '👎')
+            // .replace(/\(on\)/g, '(ON)')
+            // .replace(/\(off\)/g, '(OFF)')
+            // .replace(/\(!\)/g, '⚠️')
+
+            // .replace(/\(\*\)/g, '⭐')
+            // .replace(/\(\*r\)/g, '⭐(red)')
+            // .replace(/\(\*g\)/g, '⭐(green)')
+            // .replace(/\(\*b\)/g, '⭐(blue)')
+            // .replace(/\(\*y\)/g, '⭐(yellow)')
+
+            // .replace(/\(\/\)/g, '✅')
+            // .replace(/\(x\)/g, '❌')
+            // .replace(/\(i\)/g, 'ℹ️')
+            // .replace(/\(\+\)/g, '➕')
+            // .replace(/\(-\)/g, '➖')
+
+            // .replace(/\(\?\)/g, '❓')
+            // .replace(/<3/g, '❤️')
+            // .replace(/<\/3/g, '💔')
         );
     }
 }


### PR DESCRIPTION
In issue descriptions, Jira parses certain strings as emoticons. Jira also offers to insert these emoticons through a function in the toolbar.
See https://confluence.atlassian.com/conf80/symbols-emojis-and-special-characters-1188407348.html / "Type the emoji keyboard shortcut".

These emoticons are translated into real emojis from Jira to MD representation.
Translation from MD back to Jira has also been done, but has not been tested.

These are all the emoticons in Jira-syntax: 
```
:), :(, :P, :P, :D, ;), 
(y), (n), (on), (off), (!), 
(*), (*r), (*g), (*b), (*),
 (/), (x), (i), (+),  (-), 
(?), <3, </3
(flag), (flagoff)
```
The `flag`, `flagoff` are not supported by newer Jira editions, but are present in older ones.